### PR TITLE
The repository attribute was being ignored because it is hard-coded

### DIFF
--- a/libraries/chef_server_ingredients_provider.rb
+++ b/libraries/chef_server_ingredients_provider.rb
@@ -45,7 +45,7 @@ class Chef
 
         # TODO: create manage_package_repo boolean on resource
         # add another only_if
-        packagecloud_repo 'chef/stable' do
+        packagecloud_repo new_resource.repository do
           type value_for_platform_family(debian: 'deb', rhel: 'rpm')
           only_if { new_resource.package_source.nil? }
         end


### PR DESCRIPTION
This PR makes it respect the repository attribute, like so:

```ruby
chef_server_ingredient 'supermarket' do
  repository 'chef/current'
  notifies :reconfigure, 'chef_server_ingredient[supermarket]'
end
```

This is safe to do because the resource already specifies a default of `chef/stable`