### PR TITLE
Add timeout attribute.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ and running the `ctl reconfigure` of individual packages.
   located. If present, this file is used for installing the package.
   Default `nil`.  
 - `timeout`: The amount of time (in seconds) to wait to fetch the installer
-  before timing out. Default `900` seconds.
+  before timing out. Default: default timeout of the Chef package resource.
 
 License and Author
 ------------------

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ and running the `ctl reconfigure` of individual packages.
 - `ctl_command`: The "ctl" command, e.g., `chef-server-ctl`. This
   should be automatically detected by the library helper method
   `chef_server_ctl_command`, but may need to be specified if something
-  changes, like a new add-on is made available.    
+  changes, like a new add-on is made available.
 - `options`: Options passed to the `package` resource used for
   installation.  
 - `master_token`: Used for packagecloud private repositories.
@@ -53,6 +53,8 @@ and running the `ctl reconfigure` of individual packages.
 - `package_source`: Full path to a location where the package is
   located. If present, this file is used for installing the package.
   Default `nil`.  
+- `timeout`: The amount of time (in seconds) to wait to fetch the installer
+  before timing out. Default `900` seconds.
 
 License and Author
 ------------------

--- a/libraries/chef_server_ingredients_provider.rb
+++ b/libraries/chef_server_ingredients_provider.rb
@@ -55,6 +55,7 @@ class Chef
           version new_resource.version
           source new_resource.package_source
           provider local_provider if new_resource.package_source
+          timeout new_resource.timeout
         end
       end
 

--- a/libraries/chef_server_ingredients_resource.rb
+++ b/libraries/chef_server_ingredients_resource.rb
@@ -20,7 +20,7 @@ class Chef
       attribute :version, kind_of: String, default: nil
       attribute :installed, kind_of: [TrueClass, FalseClass, NilClass], default: false
       attribute :reconfigure, kind_of: [TrueClass, FalseClass], default: false
-      attribute :timeout, kind_of: [Integer, String], default: 900
+      attribute :timeout, kind_of: [Integer, String, NilClass], default: nil
     end
   end
 end

--- a/libraries/chef_server_ingredients_resource.rb
+++ b/libraries/chef_server_ingredients_resource.rb
@@ -20,6 +20,7 @@ class Chef
       attribute :version, kind_of: String, default: nil
       attribute :installed, kind_of: [TrueClass, FalseClass, NilClass], default: false
       attribute :reconfigure, kind_of: [TrueClass, FalseClass], default: false
+      attribute :timeout, kind_of: [Integer, String], default: 900
     end
   end
 end


### PR DESCRIPTION
Slow internet is slow and chef-server-core packages are big. Adds a timeout attribute to postpone the problem.