### PR TITLE
Fix issue where package provider override isn't working when specifying a package_source

### DIFF
--- a/libraries/chef_server_ingredients_provider.rb
+++ b/libraries/chef_server_ingredients_provider.rb
@@ -50,27 +50,13 @@ class Chef
           only_if { new_resource.package_source.nil? }
         end
 
-        if new_resource.package_source.nil?
-          # install package using default OS package provider (yum/apt)
-          package new_resource.package_name do
-            options new_resource.options
-            version new_resource.version
-            timeout new_resource.timeout
-          end
-        else # local package source or explicitly specified url
-          if node['platform_family'] == 'rhel'
-            rpm_package new_resource.package_name do
-              options new_resource.options
-              source new_resource.package_source
-              timeout new_resource.timeout
-            end
-          elsif node['platform_family'] == 'debian'
-            dpkg_package new_resource.package_name do
-              options new_resource.options
-              source new_resource.package_source
-              timeout new_resource.timeout
-            end
-          end
+        package_resource = new_resource.package_source.nil? ? :package : local_package_resource
+
+        declare_resource package_resource, new_resource.package_name do
+          options new_resource.options
+          version new_resource.version
+          source new_resource.package_source
+          timeout new_resource.timeout
         end
       end
 

--- a/libraries/chef_server_ingredients_provider.rb
+++ b/libraries/chef_server_ingredients_provider.rb
@@ -50,12 +50,27 @@ class Chef
           only_if { new_resource.package_source.nil? }
         end
 
-        package new_resource.package_name do
-          options new_resource.options
-          version new_resource.version
-          source new_resource.package_source
-          provider local_provider if new_resource.package_source
-          timeout new_resource.timeout
+        if new_resource.package_source.nil?
+          # install package using default OS package provider (yum/apt)
+          package new_resource.package_name do
+            options new_resource.options
+            version new_resource.version
+            timeout new_resource.timeout
+          end
+        else # local package source or explicitly specified url
+          if node['platform_family'] == 'rhel'
+            rpm_package new_resource.package_name do
+              options new_resource.options
+              source new_resource.package_source
+              timeout new_resource.timeout
+            end
+          elsif node['platform_family'] == 'debian'
+            dpkg_package new_resource.package_name do
+              options new_resource.options
+              source new_resource.package_source
+              timeout new_resource.timeout
+            end
+          end
         end
       end
 

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -39,6 +39,11 @@ module ChefServerIngredientsCookbook
       ctl_cmds[pkg]
     end
 
+    def local_package_resource
+      return :dpkg_package if node['platform_family'] == 'debian'
+      return :rpm_package if node['platform_family'] == 'rhel'
+    end
+
     def ctl_command
       new_resource.ctl_command || chef_server_ctl_command(new_resource.package_name)
     end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -42,6 +42,7 @@ module ChefServerIngredientsCookbook
     def local_package_resource
       return :dpkg_package if node['platform_family'] == 'debian'
       return :rpm_package if node['platform_family'] == 'rhel'
+      :package # fallback if there's no platform match
     end
 
     def ctl_command

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -39,11 +39,6 @@ module ChefServerIngredientsCookbook
       ctl_cmds[pkg]
     end
 
-    def local_provider
-      return Chef::Provider::Package::Dpkg if node['platform_family'] == 'debian'
-      return Chef::Provider::Package::Rpm if node['platform_family'] == 'rhel'
-    end
-
     def ctl_command
       new_resource.ctl_command || chef_server_ctl_command(new_resource.package_name)
     end

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,5 +1,5 @@
 name 'chef-server-ingredient'
-version '0.3.3'
+version '0.3.2'
 maintainer 'Chef Software, Inc.'
 maintainer_email 'cookbooks@chef.io'
 license 'Apache 2.0'

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,5 +1,5 @@
 name 'chef-server-ingredient'
-version '0.3.2'
+version '0.3.3'
 maintainer 'Chef Software, Inc.'
 maintainer_email 'cookbooks@chef.io'
 license 'Apache 2.0'

--- a/spec/centos_65_spec.rb
+++ b/spec/centos_65_spec.rb
@@ -4,15 +4,24 @@ describe 'test::repo' do
   cached(:centos_65) do
     ChefSpec::SoloRunner.new(
       platform: 'centos',
-      version: '6.5'
+      version: '6.5',
+      step_into: 'chef_server_ingredient'
       ) do |node|
       node.set['chef-server-core']['version'] = nil
     end.converge('test::repo')
   end
 
   context 'compiling the test recipe' do
+    it 'creates packagecloud_repo[chef/stable]' do
+      expect(centos_65).to create_packagecloud_repo('chef/stable')
+    end
+
     it 'installs chef_server_ingredient[chef-server-core]' do
       expect(centos_65).to install_chef_server_ingredient('chef-server-core')
+    end
+
+    it 'installs yum_package[chef-server-core]' do
+      expect(centos_65).to install_yum_package('chef-server-core')
     end
 
     it 'creates file[/tmp/chef-server-core.firstrun]' do
@@ -23,8 +32,40 @@ describe 'test::repo' do
       expect(centos_65).to install_chef_server_ingredient('opscode-manage')
     end
 
+    it 'installs yum_package[opscode-manage]' do
+      expect(centos_65).to install_yum_package('opscode-manage')
+    end
+
     it 'creates file[/tmp/opscode-manage.firstrun]' do
       expect(centos_65).to create_file('/tmp/opscode-manage.firstrun')
+    end
+  end
+end
+
+
+describe 'test::local' do
+  cached(:centos_65) do
+    ChefSpec::SoloRunner.new(
+      platform: 'centos',
+      version: '6.5',
+      step_into: 'chef_server_ingredient'
+      ) do |node|
+      node.set['chef-server-core']['version'] = nil
+    end.converge('test::local')
+  end
+
+  context 'compiling the test recipe' do
+    it 'installs chef_server_ingredient[chef-server-core]' do
+      expect(centos_65).to install_chef_server_ingredient('chef-server-core')
+    end
+
+    it 'uses the rpm_package provider instead of yum_package' do
+      expect(centos_65).to install_rpm_package('chef-server-core')
+      expect(centos_65).to_not install_yum_package('chef-server-core')
+    end
+
+    it 'creates file[/tmp/chef-server-core.firstrun]' do
+      expect(centos_65).to create_file('/tmp/chef-server-core.firstrun')
     end
   end
 end

--- a/spec/ubuntu_1404_spec.rb
+++ b/spec/ubuntu_1404_spec.rb
@@ -4,15 +4,24 @@ describe 'test::repo' do
   cached(:ubuntu_1404) do
     ChefSpec::SoloRunner.new(
       platform: 'ubuntu',
-      version: '14.04'
+      version: '14.04',
+      step_into: 'chef_server_ingredient'
       ) do |node|
       node.set['chef-server-core']['version'] = nil
     end.converge('test::repo')
   end
 
   context 'compiling the test recipe' do
+    it 'creates packagecloud_repo[chef/stable]' do
+      expect(ubuntu_1404).to create_packagecloud_repo('chef/stable')
+    end
+
     it 'installs chef_server_ingredient[chef-server-core]' do
       expect(ubuntu_1404).to install_chef_server_ingredient('chef-server-core')
+    end
+
+    it 'installs apt_package[chef-server-core]' do
+      expect(ubuntu_1404).to install_apt_package('chef-server-core')
     end
 
     it 'creates file[/tmp/chef-server-core.firstrun]' do
@@ -23,8 +32,39 @@ describe 'test::repo' do
       expect(ubuntu_1404).to install_chef_server_ingredient('opscode-manage')
     end
 
+    it 'installs apt_package[opscode-manage]' do
+      expect(ubuntu_1404).to install_apt_package('opscode-manage')
+    end
+
     it 'creates file[/tmp/opscode-manage.firstrun]' do
       expect(ubuntu_1404).to create_file('/tmp/opscode-manage.firstrun')
+    end
+  end
+end
+
+describe 'test::local' do
+  cached(:ubuntu_1404) do
+    ChefSpec::SoloRunner.new(
+      platform: 'ubuntu',
+      version: '14.04',
+      step_into: 'chef_server_ingredient'
+      ) do |node|
+      node.set['chef-server-core']['version'] = nil
+    end.converge('test::local')
+  end
+
+  context 'compiling the test recipe' do
+    it 'installs chef_server_ingredient[chef-server-core]' do
+      expect(ubuntu_1404).to install_chef_server_ingredient('chef-server-core')
+    end
+
+    it 'uses the rpm_package provider instead of yum_package' do
+      expect(ubuntu_1404).to install_dpkg_package('chef-server-core')
+      expect(ubuntu_1404).to_not install_apt_package('chef-server-core')
+    end
+
+    it 'creates file[/tmp/chef-server-core.firstrun]' do
+      expect(ubuntu_1404).to create_file('/tmp/chef-server-core.firstrun')
     end
   end
 end

--- a/test/fixtures/cookbooks/test/attributes/default.rb
+++ b/test/fixtures/cookbooks/test/attributes/default.rb
@@ -1,1 +1,17 @@
 default['test']['chef-server-core']['version'] = nil
+default['test']['source_url'] = case node['platform_family']
+  when 'debian'
+    if node['platform_version'].to_f == 14.04
+      'https://web-dl.packagecloud.io/chef/stable/packages/ubuntu/trusty/chef-server-core_12.0.5-1_amd64.deb'
+    elsif node['platform_version'].to_f == 12.04
+      'https://web-dl.packagecloud.io/chef/stable/packages/ubuntu/precise/chef-server-core_12.0.5-1_amd64.deb'
+    elsif node['platform_version'].to_f == 10.04
+      'https://web-dl.packagecloud.io/chef/stable/packages/ubuntu/lucid/chef-server-core_12.0.5-1_amd64.deb'
+    end
+  when 'rhel'
+    if node['platform_version'].to_i == 6
+      'https://web-dl.packagecloud.io/chef/stable/packages/el/6/chef-server-core-12.0.5-1.el6.x86_64.rpm'
+    elsif node['platform_version'].to_i == 5
+      'https://web-dl.packagecloud.io/chef/stable/packages/el/5/chef-server-core-12.0.5-1.el5.x86_64.rpm'
+    end
+  end

--- a/test/fixtures/cookbooks/test/recipes/local.rb
+++ b/test/fixtures/cookbooks/test/recipes/local.rb
@@ -1,37 +1,11 @@
 # helper methods for recipe clariy
 
-# TODO: create yum-chef and apt-chef cookbooks and move these
-# locations to node attributes. see yum-epel, yum-centos, etc for examples.
-def source_url
-  case node['platform_family']
-  when 'debian'
-    if node['platform_version'].to_f == 14.04
-      'https://web-dl.packagecloud.io/chef/stable/packages/ubuntu/trusty/chef-server-core_12.0.5-1_amd64.deb'
-    elsif node['platform_version'].to_f == 12.04
-      'https://web-dl.packagecloud.io/chef/stable/packages/ubuntu/precise/chef-server-core_12.0.5-1_amd64.deb'
-    elsif node['platform_version'].to_f == 10.04
-      'https://web-dl.packagecloud.io/chef/stable/packages/ubuntu/lucid/chef-server-core_12.0.5-1_amd64.deb'
-    end
-  when 'rhel'
-    if node['platform_version'].to_i == 6
-      'https://web-dl.packagecloud.io/chef/stable/packages/el/6/chef-server-core-12.0.5-1.el6.x86_64.rpm'
-    elsif node['platform_version'].to_i == 5
-      'https://web-dl.packagecloud.io/chef/stable/packages/el/5/chef-server-core-12.0.5-1.el5.x86_64.rpm'
-    end
-  end
-end
-
-def pkgname
-  ::File.basename(source_url)
-end
-
-def cache_path
-  Chef::Config[:file_cache_path]
-end
+pkgname = ::File.basename(node['test']['source_url'])
+cache_path = Chef::Config[:file_cache_path]
 
 # recipe
 remote_file "#{cache_path}/#{pkgname}" do
-  source "#{source_url}"
+  source node['test']['source_url']
   mode '0644'
 end
 


### PR DESCRIPTION
Per the comments in https://github.com/chef/chef/issues/3487  -  passing a provider to the package resource is unreliable and causing problems for our customers that need to specify a `package_source`

This PR also adds tests for the `test::local` recipe and gets up to 100% test coverage :smile: 

cc: @jtimberman 