### PR TITLE
use declare_resource instead of the provider property

### DIFF
--- a/libraries/chef_server_ingredients_provider.rb
+++ b/libraries/chef_server_ingredients_provider.rb
@@ -50,11 +50,12 @@ class Chef
           only_if { new_resource.package_source.nil? }
         end
 
-        package new_resource.package_name do
+        package_resource = new_resource.package_source ? local_resource : :package
+
+        declare_resource package_resource, new_resource.package_name do
           options new_resource.options
           version new_resource.version
           source new_resource.package_source
-          provider local_provider if new_resource.package_source
           timeout new_resource.timeout
         end
       end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -39,9 +39,15 @@ module ChefServerIngredientsCookbook
       ctl_cmds[pkg]
     end
 
-    def local_provider
-      return Chef::Provider::Package::Dpkg if node['platform_family'] == 'debian'
-      return Chef::Provider::Package::Rpm if node['platform_family'] == 'rhel'
+    def local_resource
+      case node['platform_family']
+      when 'debian'
+        :dpkg_package
+      when 'rhel'
+        :rpm_package
+      else
+        :package
+      end
     end
 
     def ctl_command


### PR DESCRIPTION
provider is bad because its a leaky abstraction and you don't wind up
with what you expect.  with declare_resource we will wind up with a
Chef::Resource::RpmPackage wrapping a Chef::Resource::Package::Rpm.  by
forcing the provider on Chef-11 you would get a Chef::Resource::Package
wrapping a Chef::Resource::Package::Rpm, while on Chef-12 you now get
a Chef::Resource::YumPackage wrapping a Chef::Resource::Package::Rpm.

the latter case has gotten worse in Chef-12, but that is not a bug, the
correct way to fix it is to use declare_resource.